### PR TITLE
Add colon to use statement in welcome.clj namespace

### DIFF
--- a/resources/templates/welcome.clj
+++ b/resources/templates/welcome.clj
@@ -1,9 +1,9 @@
 (ns $project$.views.welcome
   (:require [$project$.views.common :as common]
             [noir.content.pages :as pages])
-  (use noir.core
-       hiccup.core
-       hiccup.page-helpers))
+  (:use noir.core
+        hiccup.core
+        hiccup.page-helpers))
 
 (defpage "/welcome" []
          (common/layout


### PR DESCRIPTION
Tiny detail: In the auto-generated `welcome.clj` file, the `use` statement inside the `ns` should be `:use` instead of the direct function call `use`.
