### PR TITLE
Use :use instead of use in ns macro

### DIFF
--- a/resources/templates/common.clj
+++ b/resources/templates/common.clj
@@ -1,7 +1,7 @@
 (ns $project$.views.common
-  (use noir.core
-       hiccup.core
-       hiccup.page-helpers))
+  (:use noir.core
+        hiccup.core
+        hiccup.page-helpers))
 
 (defpartial layout [& content]
             (html5


### PR DESCRIPTION
Same as previous pull request, just noticed it's also the case in the `common.clj` file. Did a grep this time of the `templates` dir, didn't find any other instances of `use`, `require`, etc being used as functions within the `ns` macro.
