### PR TITLE
Updates for Clojure 1.3 and Lein2 compatibility

### DIFF
--- a/resources/templates/project.clj
+++ b/resources/templates/project.clj
@@ -1,6 +1,5 @@
 (defproject $project$ "0.1.0-SNAPSHOT"
             :description "FIXME: write this!"
-            :dependencies [[org.clojure/clojure "1.3.0"]
+            :dependencies [[org.clojure/clojure "1.4.0"]
                            [noir "1.2.1"]]
             :main $project$.server)
-

--- a/src/leiningen/noir.clj
+++ b/src/leiningen/noir.clj
@@ -7,14 +7,13 @@
     (println "No project name given:\r\n~    lein noir new my-website")
     (nnew/create proj-name)))
 
-(defn noir
+(defn ^:no-project-needed noir
   "Create and manage noir projects."
   {:help-arglists '([new])
    :subtasks [#'new]}
-  ([]
+  ([project]
      (println (help-for "noir")))
-  ([subtask & args]
+  ([project subtask & args]
      (case subtask
        "new"     (apply leiningen.noir/new args)
-       (println (help-for "noir"))
-       )))
+       (println (help-for "noir")))))

--- a/src/leiningen/noir/new.clj
+++ b/src/leiningen/noir/new.clj
@@ -2,7 +2,9 @@
   (:require [clojure.string :as string])
   (:use clojure.java.io))
 
-(declare *project-dir* *project* *dirs*)
+(declare ^:dynamic *project-dir*
+         ^:dynamic *project*
+         ^:dynamic *dirs*)
 (def dir-keys [:css :js :img :views :models :test])
 
 ;;From the maginalia source: http://fogus.me/fun/marginalia/


### PR DESCRIPTION
I think it would be nice to get these or similar fixes in since the website still points to lein-noir and current lein-noir doesn't work at all with lein2 and throws warnings with clojure 1.3.
