### PR TITLE
Allow '.' in project name when using noir lein-template 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ pom.xml
 *jar
 /lib/
 /classes/
+/target/
 .lein-deps-sum

--- a/project.clj
+++ b/project.clj
@@ -1,3 +1,3 @@
-(defproject noir/lein-template "1.3.0"
+(defproject noir/lein-template "1.3.1-SNAPSHOT"
   :description "A lein-newnew template for generating new noir projects."
   :url "https://github.com/ibdknox/lein-noir")

--- a/src/leiningen/new/noir.clj
+++ b/src/leiningen/new/noir.clj
@@ -1,5 +1,5 @@
 (ns leiningen.new.noir
-  (:use leiningen.new.templates))
+  (:use [leiningen.new.templates :only [renderer name-to-path ->files]]))
 
 (def render (renderer "noir"))
 
@@ -7,8 +7,8 @@
   "A skeleton Noir project."
   [name]
   (let [data {:name name
-              :sanitized (sanitize name)}]
-    (println "Generating a lovely new Noir project named" (str name "..."))
+              :sanitized (name-to-path name)}]
+    (println "Generating a lovely New new Noir project named" (str name "..."))
     (->files data
              ["project.clj" (render "project.clj" data)]
              [".gitignore" (render "gitignore" data)]


### PR DESCRIPTION
Thanks for the noir lein-template. Wanted to be able to do "lein new noir my.site", so here is a fix that allows dots in the project name. 
